### PR TITLE
refactor factories

### DIFF
--- a/config/autoload/models.global.php
+++ b/config/autoload/models.global.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'dependencies' => [
+        'factories' => [
+            App\Model\User::class => App\Model\UserFactory::class
+        ],
+    ],
+];

--- a/src/App/Middleware/UserFactory.php
+++ b/src/App/Middleware/UserFactory.php
@@ -10,13 +10,9 @@ class UserFactory
 {
     public function __invoke(ContainerInterface $container)
     {
-        $adapter = ($container->has(AdapterInterface::class))
-            ? $container->get(AdapterInterface::class)
-            : null;
-        $urlHelper = ($container->has(UrlHelper::class))
-            ? $container->get(UrlHelper::class)
-            : null;
+        $userModel = $container->get(UserModel::class);
+        $urlHelper = $container->get(UrlHelper::class);
 
-        return new User(new UserModel($adapter), $urlHelper);
+        return new User($userModel, $urlHelper);
     }
 }

--- a/src/App/Model/UserFactory.php
+++ b/src/App/Model/UserFactory.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Model;
+
+use Interop\Container\ContainerInterface;
+use Zend\Db\Adapter\AdapterInterface;
+
+class UserFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        $adapter = $container->get(AdapterInterface::class);
+        return new User($adapter);
+    }
+}


### PR DESCRIPTION
- no need to check if container->has() for Adapter and UrlHelper, as there is no null default value in `User::__construct()` middleware and `User::__construct` model for Adapter and UrlHelper type hint, so, just get() directly.
- added `UserFactory` for User model.
