### PR TITLE
Cast return value of addUser

### DIFF
--- a/src/App/User/UserModel.php
+++ b/src/App/User/UserModel.php
@@ -76,7 +76,7 @@ class UserModel
             );
         }
 
-        return $id;
+        return (int) $id;
     }
 
     /**


### PR DESCRIPTION
ZendDB does not enforce return types, so we need to handle possibility of strings.

> ZendDB's AbstractTableGateway.php does not declare its return type (other than in its docBlock), but UserModel.php sets a return type of int with no validation or guarantee that that the table gateway has actually returned an int.

https://github.com/ezimuel/zend-expressive-api/pull/3#issuecomment-388360022