### PR TITLE
Rename UserHandler to match file name

### DIFF
--- a/src/App/User/ModifyUserHandler.php
+++ b/src/App/User/ModifyUserHandler.php
@@ -12,7 +12,7 @@ use Zend\Expressive\Hal\HalResponseFactory;
 use Zend\Expressive\Hal\ResourceGenerator;
 use Zend\Expressive\Helper\UrlHelper;
 
-class UserHandler implements RequestHandlerInterface
+class ModifyUserHandler implements RequestHandlerInterface
 {
     private $model;
     private $inputFilter;


### PR DESCRIPTION
ModifyUserHandler.php contained the class "UserHandler". This causes a warning with generating an authoritative classmap with Composer, and the factories already appear to reference the class name "ModifyUserHandler" even though it did not exist.